### PR TITLE
Work around "path containing space" bug for default mac users

### DIFF
--- a/pycscope/__init__.py
+++ b/pycscope/__init__.py
@@ -88,14 +88,14 @@ kwlist.extend(("True", "False", "None"))
 strings_as_symbols = False
 
 def is_mac():
-	if 'darwin' in platform.platform().lower():
-		return True
-	else:
-		return False
+    if 'darwin' in platform.platform().lower():
+        return True
+    else:
+        return False
 
-def getpwd():
-	p = subprocess.Popen('pwd', stdout=subprocess.PIPE)
-	return p.stdout.readline().strip()
+def getpwd(): 
+    p = subprocess.Popen('pwd', stdout=subprocess.PIPE)
+    return p.stdout.readline().strip()
 
 def main(argv=None):
     """Parse command line args and act accordingly.
@@ -141,11 +141,11 @@ def main(argv=None):
         args = "."
 
     # Parse the given list of files/dirs
-	basepath = None
-	if is_mac():
-		basepath = getpwd()
-	else:
-		basepath = os.getcwd()
+    basepath = None
+    if is_mac():
+        basepath = getpwd()
+    else:
+        basepath = os.getcwd()
     gen = genFiles(basepath, args, recurse)
 
     if threadCount > 1:

--- a/pycscope/__init__.py
+++ b/pycscope/__init__.py
@@ -21,7 +21,7 @@ __usage__ = """Usage: pycscope.py [-D] [-R] [-S] [-V] [-t cnt] [-f reffile] [-i 
 -f reffile      Use 'reffile' as cross-ref file name instead of 'cscope.out'
 -i srclistfile  Use the contents of 'srclistfile' as the list of source files to scan"""
 
-import getopt, sys, os, os.path, string
+import getopt, sys, os, os.path, string, subprocess, platform
 import keyword, parser, symbol, token
 from threading import Lock, Thread
 
@@ -87,6 +87,16 @@ kwlist.extend(("True", "False", "None"))
 
 strings_as_symbols = False
 
+def is_mac():
+	if 'darwin' in platform.platform().lower():
+		return True
+	else:
+		return False
+
+def getpwd():
+	p = subprocess.Popen('pwd', stdout=subprocess.PIPE)
+	return p.stdout.readline().strip()
+
 def main(argv=None):
     """Parse command line args and act accordingly.
     """
@@ -131,7 +141,11 @@ def main(argv=None):
         args = "."
 
     # Parse the given list of files/dirs
-    basepath = os.getcwd()
+	basepath = None
+	if is_mac():
+		basepath = getpwd()
+	else:
+		basepath = os.getcwd()
     gen = genFiles(basepath, args, recurse)
 
     if threadCount > 1:


### PR DESCRIPTION
Cscope cannot handle space in the path, while return value of os.getcwd() in Mac usually contains string "Macintosh HD", which has a space inside. Instead, the shell command "pwd" work around this problem. This fix let mac users take pwd command instead of os.getcwd().