### PR TITLE
skip any non-ASCII characters in the files 

### DIFF
--- a/pycscope/__init__.py
+++ b/pycscope/__init__.py
@@ -23,6 +23,19 @@ __usage__ = """Usage: pycscope.py [-D] [-R] [-S] [-V] [-f reffile] [-i srclistfi
 import getopt, sys, os, string, re
 import keyword, parser, symbol, token
 
+_re_ascii_filter = '[^%s]' % (re.escape(string.printable), )
+
+def ascii_dammit( sourcecode, _re_expr = re.compile( _re_ascii_filter ) ):
+    """
+        just ignore all non-ascii characters 
+        since any identifiers should be ASCII anyway ;
+        nb: this will work for utf-8 as well
+        
+    """
+
+    result = _re_expr.sub( '', sourcecode )
+    return result
+
 
 class Mark(object):
     """ Marks, as defined by Cscope, that are implemented.
@@ -238,6 +251,7 @@ def parseFile(basepath, relpath, indexbuff, indexbuff_len, fnamesbuff, dump=Fals
     # Add path info to any syntax errors in the source files
     if filecontents:
         try:
+            filecontents = ascii_dammit( filecontents )
             indexbuff_len = parseSource(filecontents, indexbuff, indexbuff_len, dump)
         except (SyntaxError, AssertionError) as e:
             e.filename = fullpath


### PR DESCRIPTION
… since this seems to break the source code parser ; certainly the preferred way to go would be to convince the parser to accept non-ASCII characters ( Python does that, for one thing ), but as a quick fix:

===

    --- __init__.py.orig	2016-06-04 20:24:26.507343246 +1000
    +++ __init__.py	2016-06-04 20:39:29.206238307 +1000
    @@ -23,6 +23,19 @@
     import getopt, sys, os, string, re
     import keyword, parser, symbol, token
     
    +_re_ascii_filter = '[^%s]' % (re.escape(string.printable), )
    +
    +def ascii_dammit( sourcecode, _re_expr = re.compile( _re_ascii_filter ) ):
    +    """
    +        just ignore all non-ascii characters 
    +        since any identifiers should be ASCII anyway ;
    +        nb: this will work for utf-8 as well
    +        
    +    """
    +
    +    result = _re_expr.sub( '', sourcecode )
    +    return result
    +
     
     class Mark(object):
         """ Marks, as defined by Cscope, that are implemented.
    @@ -234,6 +247,7 @@
         # Add path info to any syntax errors in the source files
         if filecontents:
             try:
    +            filecontents = ascii_dammit( filecontents )
                 indexbuff_len = parseSource(filecontents, indexbuff, indexbuff_len, dump)
             except (SyntaxError, AssertionError) as e:
                 e.filename = fullpath


===

