### PR TITLE
Fix wrong offset for multibyte characters

### DIFF
--- a/pycscope/__init__.py
+++ b/pycscope/__init__.py
@@ -157,7 +157,7 @@ def writeIndex(basepath, fout, indexbuff, fnamesbuff):
     """
     # Write the header and index
     index = ''.join(indexbuff)
-    index_len = len(index)
+    index_len = len(index.encode('utf-8'))
     hdr_len = len(basepath) + 25
     fout.write("cscope 15 %s -c %010d" % (basepath, hdr_len + index_len))
     fout.write(index)


### PR DESCRIPTION
Offset in the header may be wrong if the source contains multibyte
characters.  Fix it by encoding the string to utf-8 before calculating
the offset.

For examaple:

>>> s='Exiting¡ ¬'
>>> len(s)
10
>>> len(s.encode('utf-8'))
12

Signed-off-by: Tzung-Bi Shih <penvirus@gmail.com>